### PR TITLE
Correct the link to fluent-rs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,7 +62,7 @@
             <li>Implemented in
               <a class="link" href="https://github.com/projectfluent/fluent.js">JavaScript</a>,
               <a class="link" href="https://github.com/projectfluent/python-fluent">Python</a> and
-              <a class="link" href="https://github.com/projectfluent/fluent.rs">Rust</a>
+              <a class="link" href="https://github.com/projectfluent/fluent-rs">Rust</a>
             <li>Well-defined
               <a class="link" href="https://github.com/projectfluent/fluent/tree/master/spec">EBNF grammar</a>
           </ul>


### PR DESCRIPTION
The implemented in Rust link currently goes to a 404 since it uses a period instead of a hyphen-minus.